### PR TITLE
fix catchable error in \Bitrix24\Task\Item::update()

### DIFF
--- a/src/classes/task/item.php
+++ b/src/classes/task/item.php
@@ -57,7 +57,7 @@ class Item extends Bitrix24Entity
 	 */
 	public function update($taskId, $taskData)
 	{
-		$result = $this->client->call('task.item.update', $taskId, array($taskData));
+		$result = $this->client->call('task.item.update', array($taskId, $taskData));
 		return $result;
 	}
 


### PR DESCRIPTION
Catchable fatal error:  Argument 2 passed to Bitrix24\Bitrix24::call() must be of the type array, string given.