### PR TITLE
Fixed two errors in the isAccessTokenExpire method

### DIFF
--- a/src/bitrix24.php
+++ b/src/bitrix24.php
@@ -876,7 +876,7 @@ class Bitrix24 implements iBitrix24
 //		$url = 'https://'.self::OAUTH_SERVER.'/rest/app.info?auth='.$accessToken;
         $url = 'https://' . $domain . '/rest/app.info?auth=' . $accessToken;
         $requestResult = $this->executeRequest($url);
-        if (in_array($requestResult['error'], array('expired_token', 'invalid_token', 'WRONG_TOKEN'), false)) {
+        if (isset($requestResult['error']) && in_array($requestResult['error'], array('EXPIRED_TOKEN', 'INVALID_TOKEN', 'WRONG_TOKEN'), false)) {
             $isTokenExpire = true;
         } else {
             // handle other errors

--- a/src/bitrix24.php
+++ b/src/bitrix24.php
@@ -876,11 +876,13 @@ class Bitrix24 implements iBitrix24
 //		$url = 'https://'.self::OAUTH_SERVER.'/rest/app.info?auth='.$accessToken;
         $url = 'https://' . $domain . '/rest/app.info?auth=' . $accessToken;
         $requestResult = $this->executeRequest($url);
-        if (isset($requestResult['error']) && in_array($requestResult['error'], array('EXPIRED_TOKEN', 'INVALID_TOKEN', 'WRONG_TOKEN'), false)) {
-            $isTokenExpire = true;
-        } else {
-            // handle other errors
-            $this->handleBitrix24APILevelErrors($requestResult, 'app.info');
+        if (isset($requestResult['error'])) {
+            if (in_array($requestResult['error'], array('EXPIRED_TOKEN', 'INVALID_TOKEN', 'WRONG_TOKEN'), false)) {
+                $isTokenExpire = true;
+            } else {
+                // handle other errors
+                $this->handleBitrix24APILevelErrors($requestResult, 'app.info');
+            }
         }
         return $isTokenExpire;
     }// end of isTokenExpire


### PR DESCRIPTION
**First fix:**
If executeRequest results in no error, the isTokenExpire should be false.
With the current code, it always returned true and showed a PHP Notice.

**Second fix:**
Using isAccessTokenExpire returned incorrect errors when the token was in fact expired due to a mismatch between the returned values EXPIRED_TOKEN and INVALID_TOKEN which were checked with expired_token and invalid_token in non-caps.