### PR TITLE
Added Bad gateway exception

### DIFF
--- a/src/bitrix24.php
+++ b/src/bitrix24.php
@@ -11,6 +11,7 @@ namespace Bitrix24;
 
 use Bitrix24\Contracts\iBitrix24;
 
+use Bitrix24\Exceptions\Bitrix24BadGatewayException;
 use Bitrix24\Exceptions\Bitrix24Exception;
 use Bitrix24\Exceptions\Bitrix24IoException;
 use Bitrix24\Exceptions\Bitrix24PaymentRequiredException;
@@ -555,6 +556,12 @@ class Bitrix24 implements iBitrix24
                 $errorMsg = sprintf('portal [%s] deleted, query aborted', $this->getDomain());
                 $this->log->error($errorMsg, $this->getErrorContext());
                 throw new Bitrix24PortalDeletedException($errorMsg);
+                break;
+            
+            case 502:
+                $errorMsg = sprintf('bad gateway to portal [%s]', $this->getDomain());
+                $this->log->error($errorMsg, $this->getErrorContext());
+                throw new Bitrix24BadGatewayException($errorMsg);
                 break;
         }
 

--- a/src/exceptions/bitrix24badgatewayexception.php
+++ b/src/exceptions/bitrix24badgatewayexception.php
@@ -13,6 +13,6 @@ namespace Bitrix24\Exceptions;
  * Class Bitrix24BadGatewayException
  * @package Bitrix24
  */
-class Bitrix24BadGatewayException extends Bitrix24Exception
+class Bitrix24BadGatewayException extends Bitrix24IoException
 {
 }

--- a/src/exceptions/bitrix24badgatewayexception.php
+++ b/src/exceptions/bitrix24badgatewayexception.php
@@ -1,0 +1,18 @@
+<?php
+/*
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Mesilov Maxim <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Bitrix24\Exceptions;
+
+/**
+ * Class Bitrix24BadGatewayException
+ * @package Bitrix24
+ */
+class Bitrix24BadGatewayException extends Bitrix24Exception
+{
+}


### PR DESCRIPTION
In one in 1.500 requests, Bitrix returns a 502 BAD GATEWAY response.
This response throws a generix Bitrix24Exception with a json_decode error.
I added a 502 status code check and a BadGateway exception class so this type of error can be caught in a separate try/catch

