### PR TITLE
Support for batch calls

### DIFF
--- a/src/bitrix24.php
+++ b/src/bitrix24.php
@@ -45,6 +45,16 @@ class Bitrix24 implements iBitrix24
     const OAUTH_SERVER = 'oauth.bitrix.info';
 
     /**
+     * Max calls in one batch
+     */
+    const MAX_BATCH_CALLS = 50;
+
+    /**
+     * Default delay between batch calls (in msec)
+     */
+    const BATCH_DELAY = 500000;
+
+    /**
      * @var string access token
      */
     protected $accessToken;
@@ -129,6 +139,11 @@ class Bitrix24 implements iBitrix24
      * @var integer retries to connect timeout in microseconds
      */
     protected $retriesToConnectTimeout;
+
+    /**
+     * @var array pending batch calls
+     */
+    protected $_batch = array();
 
     /**
      * Create a object to work with Bitrix24 REST API service
@@ -1017,5 +1032,67 @@ class Bitrix24 implements iBitrix24
     public function getRetriesToConnectTimeout()
     {
         return $this->retriesToConnectTimeout;
+    }
+
+    /**
+     * Add call to batch. If [[$callback]] parameter is set, it will receive call result as first parameter.
+     *
+     * @param string $method
+     * @param array $parameters
+     * @param callable|null $callback
+     */
+    public function addBatchCall($method, array $parameters = array(), callable $callback = null)
+    {
+        $this->_batch[] = array(
+            'method' => $method,
+            'parameters' => $parameters,
+            'callback' => $callback,
+        );
+    }
+
+    /**
+     * Return true, if we have unprocessed batch calls.
+     *
+     * @return bool
+     */
+    public function hasBatchCalls()
+    {
+        return (bool) count($this->_batch);
+    }
+
+    /**
+     * Process batch calls.
+     *
+     * @param int $halt Halt batch on error
+     * @param int $delay Delay between batch calls (in msec)
+     * @throws Bitrix24Exception
+     * @throws Bitrix24SecurityException
+     */
+    public function processBatchCalls($halt = 0, $delay = self::BATCH_DELAY)
+    {
+        while (count($this->_batch)) {
+            $slice = array_splice($this->_batch, 0, self::MAX_BATCH_CALLS);
+            $commands = array();
+            foreach ($slice as $idx => $call) {
+                $commands[$idx] = $call['method'] . '?' . http_build_query($call['parameters']);
+            }
+            $batchResult = $this->call('batch', array('halt' => $halt, 'cmd' => $commands));
+            $results = $batchResult['result'];
+            foreach ($slice as $idx => $call) {
+                if (!isset($call['callback']) || !is_callable($call['callback'])) {
+                    continue;
+                }
+
+                call_user_func($call['callback'], array(
+                    'result' => isset($results['result'][$idx]) ? $results['result'][$idx] : null,
+                    'error' => isset($results['result_error'][$idx]) ? $results['result_error'][$idx] : null,
+                    'total' => isset($results['result_total'][$idx]) ? $results['result_total'][$idx] : null,
+                    'next' => isset($results['result_next'][$idx]) ? $results['result_next'][$idx] : null,
+                ));
+            }
+            if (count($this->_batch) && $delay) {
+                usleep($delay);
+            }
+        }
     }
 }

--- a/src/bitrix24.php
+++ b/src/bitrix24.php
@@ -1040,14 +1040,18 @@ class Bitrix24 implements iBitrix24
      * @param string $method
      * @param array $parameters
      * @param callable|null $callback
+     *
+     * @return string Unique call ID.
      */
     public function addBatchCall($method, array $parameters = array(), callable $callback = null)
     {
-        $this->_batch[] = array(
+        $id = uniqid();
+        $this->_batch[$id] = array(
             'method' => $method,
             'parameters' => $parameters,
             'callback' => $callback,
         );
+        return $id;
     }
 
     /**


### PR DESCRIPTION
See #2.

Examples:
1. If you have about 2000 contacts in CRM, you can dump them in just 2 (two) API calls:
```php
$contacts = [];
$api->addBatchCall('crm.contact.list', [
    'select' => ['ID', 'NAME'], 'order' => ['ID' => 'ASC'],
], function ($result) use ($api, &$contacts) {
    // save first page
    foreach ($result['result'] as $contact) {
        $contacts[$contact['ID']] = $contact;
    }
    // add calls for subsequent pages
    for ($i = $result['next']; $i < $result['total']; $i += $result['next']) {
        $api->addBatchCall('crm.contact.list', [
            'start' => $i, 'select' => ['ID', 'NAME'], 'order' => ['ID' => 'ASC'],
        ], function ($result) use (&$contacts) {
            // save subsequent page
            foreach ($result['result'] as $contact) {
                $contacts[$contact['ID']] = $contact;
            }
        });
    }
});
$api->processBatchCalls();
var_dump($contacts);
```
2. If you need to create 100 contacts in CRM, you can do it also in 2 API calls:
```php
$contacts = [];
for ($i = 1; $i <= 100; $i++) {
    $contacts[] = [
        'NAME' => sprintf('Contact #%d', $i),
    ];
}
foreach ($contacts as &$contact) {
    $api->addBatchCall('crm.contact.add', [
        'fields' => $contact,
        'params' => ['REGISTER_SONET_EVENT' => 'N'],
    ], function ($result) use (&$contact) {
        if ($result['error']) {
            // handle error
            return;
        }
        $contact['bitrixContactId'] = $result['result'];
    });
}
$api->processBatchCalls();
var_dump($contacts);
```
3. You can also mix various methods. For instance, you can dump leads statuses and custom fields in one API call:
```php
$statuses = [];
$api->addBatchCall('crm.status.list',
    ['order' => ['SORT' => 'ASC'], 'filter' => ['ENTITY_ID' => 'DEAL_STAGE']],
    function ($result) use (&$statuses) {
        foreach ($result['result'] as $status) {
            $statuses[$status['STATUS_ID']] = $status['NAME'];
        }
    }
);
$fields = [];
$api->addBatchCall('crm.contact.userfield.list',
    ['order' => ['SORT' => 'ASC'], 'filter' => ['LANG' => 'RU']],
    function ($result) use (&$fields) {
        foreach ($result['result'] as $field) {
            $fields[$field['FIELD_NAME']] = $field['EDIT_FORM_LABEL'];
        }
    }
);
$api->processBatchCalls();
var_dump($statuses);
var_dump($fields);
```
As batch calls can take a lot of time, don't forget to adjust default timeout:
```php
$api->setCustomCurlOptions([
    CURLOPT_TIMEOUT => 60,
]);
```