### PR TITLE
Callback for expired token

### DIFF
--- a/src/bitrix24.php
+++ b/src/bitrix24.php
@@ -131,6 +131,22 @@ class Bitrix24 implements iBitrix24
     protected $retriesToConnectTimeout;
 
     /**
+     * @var callable callback for expired tokens
+     */
+    protected $_onExpiredToken;
+
+    /**
+     * Set function called on token expiration. Callback receives instance as first parameter.
+     * If callback returns true, API call will be retried.
+     *
+     * @param callable $callback
+     */
+    public function setOnExpiredToken(callable $callback)
+    {
+        $this->_onExpiredToken = $callback;
+    }
+
+    /**
      * Create a object to work with Bitrix24 REST API service
      *
      * @param bool $isSaveRawResponse - if true raw response from bitrix24 will be available from method getRawResponse, this is debug mode
@@ -607,7 +623,7 @@ class Bitrix24 implements iBitrix24
      *
      * @return array
      */
-    public function call($methodName, array $additionalParameters = array())
+    protected function _call($methodName, array $additionalParameters = array())
     {
 //		$arAuthServerMethods = array(
 //			'app.info',
@@ -691,6 +707,45 @@ class Bitrix24 implements iBitrix24
             }
         }
         return $requestResult;
+    }
+
+    /**
+     * Execute Bitrix24 REST API method
+     *
+     * @param string $methodName
+     * @param array $additionalParameters
+     *
+     * @throws Bitrix24Exception
+     * @throws Bitrix24ApiException
+     * @throws Bitrix24TokenIsInvalidException
+     * @throws Bitrix24TokenIsExpiredException
+     * @throws Bitrix24WrongClientException
+     * @throws Bitrix24MethodNotFoundException
+     * @throws Bitrix24PaymentRequiredException
+     * @throws Bitrix24SecurityException
+     * @throws Bitrix24PortalDeletedException
+     * @throws Bitrix24IoException
+     * @throws Bitrix24EmptyResponseException
+     *
+     * @return array
+     */
+    public function call($methodName, array $additionalParameters = array())
+    {
+        try {
+            $result = $this->_call($methodName, $additionalParameters);
+        } catch (Bitrix24TokenIsExpiredException $e) {
+            if (!is_callable($this->_onExpiredToken)) {
+                throw $e;
+            }
+
+            $retry = call_user_func($this->_onExpiredToken, $this);
+            if (!$retry) {
+                throw $e;
+            }
+            $result = $this->_call($methodName, $additionalParameters);
+        }
+        
+        return $result;
     }
 
     /**


### PR DESCRIPTION
Token expiration is very annoying, if you have dozens of API calls in different places. You need to catch specific exception, refresh token and retry missed call somehow.

So, here is a solution: if token is expired, some callback function will be called. This callback function can refresh token, so missed call can be retried.

Here is an example of such callback function usage:
```php
$api->setOnExpiredToken(function (\Bitrix24\Bitrix24 $api) {
    $token = $api->getNewAccessToken();
    $api->setAccessToken($token['access_token']);
    $api->setRefreshToken($token['refresh_token']);
    // save new token pair somewhere
    return true;
});
```
If there is no callback function set, or it doesn't return `true`, good old `Bitrix24TokenIsExpiredException` will be thrown. So there is no backward compatibility break.