### PR TITLE
Fix namespace for Deal class

### DIFF
--- a/src/classes/crm/deal/deal.php
+++ b/src/classes/crm/deal/deal.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Bitrix24\CRM\Deal;
+namespace Bitrix24\CRM;
 
 use Bitrix24\Bitrix24Entity;
 


### PR DESCRIPTION
Namespace for Deal class does not match other classes. This PR corrects that.

But even with this change made, the Deal class is still not being autoloaded, and I can't figure out why. Can you see why?