### PR TITLE
Fix an error when trying to add a list to a task

### DIFF
--- a/src/classes/task/checklistitem.php
+++ b/src/classes/task/checklistitem.php
@@ -76,7 +76,7 @@ class ChecklistItem extends Bitrix24Entity
 	 */
 	public function add($taskId, $fields)
 	{
-		$result = $this->client->call('task.checklistitem.add', array($taskId, array($fields)));
+		$result = $this->client->call('task.checklistitem.add', array($taskId, $fields));
 		return $result;
 	}
 


### PR DESCRIPTION
Fix error: 
`ERROR_CORE - TASKS_ERROR_EXCEPTION_#256; 5a568096642167.33132496: Param #1 (arFields) for method ctaskchecklistitem::add() must not contain key "0".; 256/TE/WRONG_ARGUMENTS<br> in call [task.checklistitem.add] `