### PR TITLE
Fixed CRM.Company.update

### DIFF
--- a/src/classes/crm/company/company.php
+++ b/src/classes/crm/company/company.php
@@ -63,8 +63,10 @@ class Company extends Bitrix24Entity
 	{
 		$fullResult = $this->client->call(
 			'crm.company.update',
-			array('id' => $bitrix24CompanyId),
-			array('fields' => $fields)
+			array(
+                            'id' => $bitrix24CompanyId,
+                            'fields' => $fields,
+                        )
 		);
 		return $fullResult;
 	}

--- a/tests/src/classes/crm/company/companyTest.php
+++ b/tests/src/classes/crm/company/companyTest.php
@@ -12,6 +12,7 @@ namespace Bitrix24\CRM;
 use Bitrix24\CRM\Company;
 use Bitrix24\Contracts\iBitrix24;
 
+
 /**
  * @package Bitrix24
  */
@@ -27,11 +28,11 @@ class CompanyTest extends \PHPUnit_Framework_TestCase
 
         //silly mocking in PHPUnit 4.8
         $methods = array();
-        $ref = new \ReflectionClass(iBitrix24::class);
+        $ref = new \ReflectionClass('Bitrix24\\Contracts\\iBitrix24');
         foreach ($ref->getMethods() as $method) {
             $methods[] = $method->getName();
         }
-        $client = $this->getMockBuilder(iBitrix24::class)
+        $client = $this->getMockBuilder('Bitrix24\\Contracts\\iBitrix24')
             ->setMethods($methods)
             ->getMock();
         $client->expects($this->once())

--- a/tests/src/classes/crm/company/companyTest.php
+++ b/tests/src/classes/crm/company/companyTest.php
@@ -1,0 +1,50 @@
+<?php
+/*
+ * This file is part of the bitrix24-php-sdk package.
+ *
+ * © Mesilov Maxim <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace Bitrix24\CRM;
+
+use Bitrix24\CRM\Company;
+use Bitrix24\Contracts\iBitrix24;
+
+/**
+ * @package Bitrix24
+ */
+class CompanyTest extends \PHPUnit_Framework_TestCase
+{
+    public function testUpdateCallsClientWithIdAndFields()
+    {
+        $testId = \md5(\time());
+        $testField = \md5($testId);
+        $testFields = [
+            $testField => \md5($testField),
+        ];
+
+        //silly mocking in PHPUnit 4.8
+        $methods = array();
+        $ref = new \ReflectionClass(iBitrix24::class);
+        foreach ($ref->getMethods() as $method) {
+            $methods[] = $method->getName();
+        }
+        $client = $this->getMockBuilder(iBitrix24::class)
+            ->setMethods($methods)
+            ->getMock();
+        $client->expects($this->once())
+            ->method('call')
+            ->with(
+                'crm.company.update',
+                array(
+                    'id' => $testId,
+                    'fields' => $testFields,
+                )
+            );
+
+        $company = new Company($client);
+        $company->update($testId, $testFields);
+    }
+}


### PR DESCRIPTION
CRM.Company.update is broken, because it does not send the values to update. It sends just the ID of the company.
This pull request fixes this issue