### PR TITLE
Return the correct scope list

### DIFF
--- a/src/bitrix24.php
+++ b/src/bitrix24.php
@@ -274,6 +274,7 @@ class Bitrix24 implements iBitrix24
             '&grant_type=refresh_token' .
             '&client_secret=' . $applicationSecret .
             '&refresh_token=' . $refreshToken .
+            '&scope=' . implode(',', $applicationScope) .
             '&redirect_uri=' . urlencode($redirectUri);
         $requestResult = $this->executeRequest($url);
         // handling bitrix24 api-level errors


### PR DESCRIPTION
Если не передать текущие scope, то в возврате будет только один scope: app, что не соответствует списку наших текущих scope. Если мы в запросе отдадим наш список scope, то и в ответе его же получим.