### PR TITLE
Minor changes: added URL prefix and enabled API calls without a token.

### DIFF
--- a/src/bitrix24.php
+++ b/src/bitrix24.php
@@ -63,6 +63,11 @@ class Bitrix24 implements iBitrix24
     protected $domain;
 
     /**
+     * @var string urlPrefix
+     */
+    protected $urlPrefix;
+
+    /**
      * @var array scope
      */
     protected $applicationScope = array();
@@ -369,6 +374,23 @@ class Bitrix24 implements iBitrix24
         $this->refreshToken = $refreshToken;
 
         return true;
+    }
+
+
+    /**
+     * @return string
+     */
+    public function getUrlPrefix (): string
+    {
+        return $this->urlPrefix;
+    }
+
+    /**
+     * @param string $urlPrefix
+     */
+    public function setUrlPrefix (string $urlPrefix): void
+    {
+        $this->urlPrefix = $urlPrefix;
     }
 
     /**
@@ -1154,12 +1176,14 @@ class Bitrix24 implements iBitrix24
         if (null === $this->getDomain()) {
             throw new Bitrix24Exception('domain not found, you must call setDomain method before');
         }
-        if (null === $this->getAccessToken()) {
-            throw new Bitrix24Exception('access token not found, you must call setAccessToken method before');
-        }
+//        if (null === $this->getAccessToken()) {
+//            throw new Bitrix24Exception('access token not found, you must call setAccessToken method before');
+//        }
         if ('' === $methodName) {
             throw new Bitrix24Exception('method name not found, you must set method name');
         }
+        if ($prefix = $this -> getUrlPrefix())
+            $methodName = $prefix . $methodName;
 
         $url = 'https://' . $this->domain . '/rest/' . $methodName;
         $additionalParameters['auth'] = $this->accessToken;

--- a/src/bitrix24.php
+++ b/src/bitrix24.php
@@ -380,7 +380,7 @@ class Bitrix24 implements iBitrix24
     /**
      * @return string
      */
-    public function getUrlPrefix (): string
+    public function getUrlPrefix ()
     {
         return $this->urlPrefix;
     }
@@ -388,7 +388,7 @@ class Bitrix24 implements iBitrix24
     /**
      * @param string $urlPrefix
      */
-    public function setUrlPrefix (string $urlPrefix): void
+    public function setUrlPrefix (string $urlPrefix)
     {
         $this->urlPrefix = $urlPrefix;
     }


### PR DESCRIPTION
This enables direct webhook requests. 
To use this, a URL prefix should be added.

EXAMPLE:
Required URI:
https://{DOMAIN}/rest/1/{TOKEN}/{METHOD}/

Usage:

    public static function makeLeadClient(): Lead {
        $client = new Bitrix24();
        $client -> setDomain(config('Bitrix.DOMAIN'));
        $client -> setUrlPrefix('1/'.config('Bitrix.TOKEN').'/');
        return new Lead($client);
    }

    $lead = Wrapper::makeLeadClient();
    $lead -> getList(); // Returns a valid list of leads


