### PR TITLE
Add Request ID to query string parameters

### DIFF
--- a/src/Core/ApiClient.php
+++ b/src/Core/ApiClient.php
@@ -84,7 +84,6 @@ class ApiClient implements ApiClientInterface
      * @return RenewedAccessToken
      * @throws InvalidArgumentException
      * @throws TransportExceptionInterface
-     * @throws \JsonException
      * @throws TransportException
      */
     public function getNewAccessToken(): RenewedAccessToken
@@ -110,6 +109,7 @@ class ApiClient implements ApiClientInterface
                     'client_id' => $this->getCredentials()->getApplicationProfile()->getClientId(),
                     'client_secret' => $this->getCredentials()->getApplicationProfile()->getClientSecret(),
                     'refresh_token' => $this->getCredentials()->getAccessToken()->getRefreshToken(),
+                    $this->requestIdGenerator->getQueryStringParameterName() => $requestId
                 ]
             )
         );
@@ -170,8 +170,9 @@ class ApiClient implements ApiClientInterface
             }
             $parameters['auth'] = $this->getCredentials()->getAccessToken()->getAccessToken();
         }
-
-
+        // duplicate request id in query string for current version of bitrix24 api
+        // vendor don't use request id from headers =(
+        $url .= '?' . $this->requestIdGenerator->getQueryStringParameterName() . '=' . $requestId;
         $requestOptions = [
             'json' => $parameters,
             'headers' => array_merge(

--- a/src/Infrastructure/HttpClient/RequestId/DefaultRequestIdGenerator.php
+++ b/src/Infrastructure/HttpClient/RequestId/DefaultRequestIdGenerator.php
@@ -8,12 +8,19 @@ use Symfony\Component\Uid\Uuid;
 
 class DefaultRequestIdGenerator implements RequestIdGeneratorInterface
 {
-    private const DEFAULT_REQUEST_ID_FIELD_NAME = 'X-Request-ID';
+    private const DEFAULT_REQUEST_ID_HEADER_FIELD_NAME = 'X-Request-ID';
+    private const DEFAULT_QUERY_STRING_PARAMETER_NAME = 'request_id';
     private const KEY_NAME_VARIANTS = [
         'REQUEST_ID',
         'HTTP_X_REQUEST_ID',
         'UNIQUE_ID'
     ];
+
+    public function getQueryStringParameterName(): string
+    {
+        return self::DEFAULT_QUERY_STRING_PARAMETER_NAME;
+    }
+
 
     private function generate(): string
     {
@@ -23,13 +30,11 @@ class DefaultRequestIdGenerator implements RequestIdGeneratorInterface
     private function findExists(): ?string
     {
         $candidate = null;
-        foreach(self::KEY_NAME_VARIANTS as $key)
-        {
-           if(!empty($_SERVER[$key]))
-           {
-               $candidate = $_SERVER[$key];
-               break;
-           }
+        foreach (self::KEY_NAME_VARIANTS as $key) {
+            if (!empty($_SERVER[$key])) {
+                $candidate = $_SERVER[$key];
+                break;
+            }
         }
         return $candidate;
     }
@@ -45,6 +50,6 @@ class DefaultRequestIdGenerator implements RequestIdGeneratorInterface
 
     public function getHeaderFieldName(): string
     {
-        return self::DEFAULT_REQUEST_ID_FIELD_NAME;
+        return self::DEFAULT_REQUEST_ID_HEADER_FIELD_NAME;
     }
 }

--- a/src/Infrastructure/HttpClient/RequestId/RequestIdGeneratorInterface.php
+++ b/src/Infrastructure/HttpClient/RequestId/RequestIdGeneratorInterface.php
@@ -9,4 +9,6 @@ interface RequestIdGeneratorInterface
     public function getRequestId(): string;
 
     public function getHeaderFieldName(): string;
+
+    public function getQueryStringParameterName():string;
 }


### PR DESCRIPTION
The Request ID parameter is now included in query strings in addition to the header field for improved tracking. This change was made to accommodate for the current version of the Bitrix24 API that does not use Request ID from headers. A corresponding `getQueryStringParameterName` method was also added to the `RequestIdGeneratorInterface`.