### PR TITLE
Enhance Duplicates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.idea*
+/.vscode*
 /app
 vendor
 composer.phar

--- a/src/Services/CRM/Duplicates/Result/DuplicateResult.php
+++ b/src/Services/CRM/Duplicates/Result/DuplicateResult.php
@@ -6,45 +6,157 @@ namespace Bitrix24\SDK\Services\CRM\Duplicates\Result;
 
 use Bitrix24\SDK\Core\Exceptions\BaseException;
 use Bitrix24\SDK\Core\Result\AbstractResult;
+use Bitrix24\SDK\Services\CRM\Duplicates\Service\EntityType;
 
+/**
+ * Class DuplicateResult
+ * Handles the results for CRM duplicate checks.
+ */
 class DuplicateResult extends AbstractResult
 {
+    /**
+     * Private helper method to check for the existence of items of a given type.
+     * @param EntityType $entityType The type of entity to check.
+     * @param int $count The number of items to check for.
+     * @return bool True if the number of items is greater than or equal to the specified count.
+     */
+    private function hasItems(EntityType $entityType, int $count = 1): bool
+    {
+        $entityTypeValue = $entityType->value;
+        $items = $this->getCoreResponse()->getResponseData()->getResult()[$entityTypeValue] ?? [];
+        return count($items) >= $count;
+    }
+
+    /**
+     * Checks if there is exactly one match for a given entity type.
+     * @param EntityType $entityType The entity type to check.
+     * @return bool True if there is only one match.
+     */
+    public function hasOne(EntityType $entityType): bool
+    {
+        return $this->hasItems($entityType, 1) && count($this->getCoreResponse()->getResponseData()->getResult()[$entityType ->value]) === 1;
+    }
+
+     /**
+     * Checks if there is more than one match for a given entity type.
+     * @param EntityType $entityType The entity type to check.
+     * @return bool True if 2 or more duplicates.
+     */
+    public function hasDuplicates(EntityType $entityType): bool
+    {
+        return $this->hasItems($entityType, 2);
+    }
+
+    /**
+     * Checks if there are any matches for a given entity type.
+     * @param EntityType $entityType The entity type to check
+     * @return bool True if there are any matches.
+     */
+    public function hasMatches(EntityType $entityType): bool
+    {
+        return $this->hasItems($entityType, 1);
+    }
+
+    /**
+     * Checks if there are any matches across all entity types.
+     * @return bool True if there are matches for any entity type.
+     */
+    public function hasAnyMatches(): bool
+    {
+        foreach (EntityType::cases() as $entityType) {
+            if ($this->hasMatches($entityType)) {
+                return true;
+            }
+        }
+    
+        return false;
+    }
+
+    // Backward compatible methods
     public function hasDuplicateContacts(): bool
     {
-        if (!array_key_exists('CONTACT', $this->getCoreResponse()->getResponseData()->getResult())) {
-            return false;
-        }
-
-        if (count($this->getCoreResponse()->getResponseData()->getResult()['CONTACT']) > 1) {
-            return true;
-        }
-
-        return false;
+        return $this->hasDuplicates(EntityType::Contact);
     }
 
     public function hasOneContact(): bool
     {
-        if (!array_key_exists('CONTACT', $this->getCoreResponse()->getResponseData()->getResult())) {
-            return false;
-        }
-
-        if (count($this->getCoreResponse()->getResponseData()->getResult()['CONTACT']) === 1) {
-            return true;
-        }
-
-        return false;
+        return $this->hasOne(EntityType::Contact);
     }
 
     /**
-     * @return array<int>
-     * @throws BaseException
+     * Retrieves the IDs of a specific entity type.
+     *
+     * @param EntityType $entityType The entity type for which to retrieve IDs.
+     * @return array<int> The array of IDs.
+     * @throws BaseException If an error occurs during the API call.
      */
-    public function getContactsId(): array
+    public function getEntityIds(EntityType $entityType): array
     {
-        if (!array_key_exists('CONTACT', $this->getCoreResponse()->getResponseData()->getResult())) {
+        $entityTypeValue = $entityType->value;
+
+        if (!array_key_exists($entityTypeValue, $this->getCoreResponse()->getResponseData()->getResult())) {
             return [];
         }
 
-        return $this->getCoreResponse()->getResponseData()->getResult()['CONTACT'];
+        return $this->getCoreResponse()->getResponseData()->getResult()[$entityTypeValue];
     }
+
+    public function getContactsId(): array //backward-compatibility name
+    {
+        return $this->getEntityIds(EntityType::Contact);
+    }
+
+    public function getCompanyIds(): array
+    {
+        return $this->getEntityIds(EntityType::Company);
+    }
+
+    public function getLeadIds(): array
+    {
+        return $this->getEntityIds(EntityType::Lead);
+    }
+
+
+    /**
+     * Returns the ID of a match for a given entity type, with optional sorting to return either the first or last ID.
+     *
+     * @param EntityType $entityType The entity type for which to retrieve a match ID.
+     * @param string $sortOrder Optional sorting order, 'asc' return older entity, 'desc' for the newest. Default is 'desc'.
+     * @return int|null ID of the match, or null if no matches found.
+     */
+    public function getMatchId(EntityType $entityType, string $sortOrder = 'desc'): ?int
+    {
+        $entityIds = $this->getEntityIds($entityType);
+        
+        if (empty($entityIds)) {
+            return null;
+        }
+        
+        return $sortOrder === 'desc' ? end($entityIds) :reset($entityIds);
+    }
+    
+
+    /**
+     * Returns the ID and EntityType of the first match found based on the provided priority order.
+     *
+     * @param array $entityTypesOrder Array of EntityType objects in the order of priority. (Defaults Lead > Contact > Company)
+     * @param string $sortOrder Optional sorting order, 'asc' return older entity, 'desc' for the newest. Default is 'desc'.
+     * @return array|null ID of the first match or null if no matches found.
+     */
+    public function getMatchIdByPriority(array $entityTypesOrder = [EntityType::Lead, EntityType::Contact, EntityType::Company], string $sortOrder = 'desc'): ?array
+    {
+        foreach ($entityTypesOrder as $entityType) {
+            // Используем getMatchId для получения ID с учетом сортировки
+            $matchId = $this->getMatchId($entityType, $sortOrder);
+            if ($matchId !== null) {
+                return [
+                    'id' => $matchId,
+                    'entityType' => $entityType,
+                    'entityTypeValue' => $entityType->value,
+                ];
+            }
+        }
+    
+        return null;
+    }    
 }

--- a/src/Services/CRM/Duplicates/Service/Duplicate.php
+++ b/src/Services/CRM/Duplicates/Service/Duplicate.php
@@ -11,37 +11,35 @@ use Bitrix24\SDK\Services\CRM\Duplicates\Result\DuplicateResult;
 
 class Duplicate extends AbstractService
 {
-    /**
-     * @param array<string> $phones
-     * @param EntityType|null $entityType
+     /**
+     * Generic method to find duplicates by communication type.
+     * 
+     * @link https://training.bitrix24.com/rest_help/crm/auxiliary/duplicates/crm.duplicate.findbycomm.php
+     * @param string $type 'PHONE' or 'EMAIL'
+     * @param array<string> $values Array containing up to 20 phone numbers or emails
+     * @param EntityType|null $entityType Can be skipped: all three entity types will be returned in this case. If this parameter is used, you can operate only with one of them. If you specify an array or non-existent parameter, all entity types will be returned.
      * @return DuplicateResult
      * @throws BaseException
      * @throws TransportException
      */
-    public function findByPhone(array $phones, ?EntityType $entityType = null): mixed
+    private function findByCommType(string $type, array $values, ?EntityType $entityType = null): DuplicateResult
     {
-        return new DuplicateResult($this->core->call('crm.duplicate.findbycomm',
-            [
-                'type' => 'PHONE',
-                'values' => $phones,
-                'entity_type' => $entityType?->value
-            ]));
+        $response = $this->core->call('crm.duplicate.findbycomm', [
+            'type' => $type,
+            'values' => $values,
+            'entity_type' => $entityType?->value
+        ]);
+
+        return new DuplicateResult($response);
     }
 
-    /**
-     * @param array<string> $emails
-     * @param EntityType|null $entityType
-     * @return DuplicateResult
-     * @throws BaseException
-     * @throws TransportException
-     */
-    public function findByEmail(array $emails, ?EntityType $entityType = null): DuplicateResult
+    public function findByPhone(array $phones, ?EntityType $entityType): DuplicateResult
     {
-        return new DuplicateResult($this->core->call('crm.duplicate.findbycomm',
-            [
-                'type' => 'EMAIL',
-                'values' => $emails,
-                'entity_type' => $entityType?->value
-            ]));
+        return $this->findByCommType('PHONE', $phones, $entityType);
+    }
+
+    public function findByEmail(array $emails, ?EntityType $entityType): DuplicateResult
+    {
+        return $this->findByCommType('EMAIL', $emails, $entityType);
     }
 }

--- a/tests/Integration/Services/CRM/Duplicates/Service/DuplicateTest.php
+++ b/tests/Integration/Services/CRM/Duplicates/Service/DuplicateTest.php
@@ -7,6 +7,8 @@ namespace Bitrix24\SDK\Tests\Integration\Services\CRM\Duplicates\Service;
 use Bitrix24\SDK\Core\Exceptions\BaseException;
 use Bitrix24\SDK\Core\Exceptions\TransportException;
 use Bitrix24\SDK\Services\CRM\Contact\Service\Contact;
+use Bitrix24\SDK\Services\CRM\Lead\Service\Lead;
+use Bitrix24\SDK\Services\CRM\Duplicates\Service\EntityType;
 use Bitrix24\SDK\Services\CRM\Duplicates\Service\Duplicate;
 use Bitrix24\SDK\Tests\Integration\Fabric;
 use PHPUnit\Framework\TestCase;
@@ -14,7 +16,227 @@ use PHPUnit\Framework\TestCase;
 class DuplicateTest extends TestCase
 {
     protected Contact $contactService;
+    // protected Company $companyService;
+    protected Lead $leadService;
     protected Duplicate $duplicate;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->contactService = Fabric::getServiceBuilder()->getCRMScope()->contact();
+        $this->leadService = Fabric::getServiceBuilder()->getCRMScope()->lead();
+        // $this->companyService = Fabric::getServiceBuilder()->getCRMScope()->company(); //нет такого
+        $this->duplicate = Fabric::getServiceBuilder()->getCRMScope()->duplicate();
+    }
+
+    /**
+     * Комплексное тестирование методов дубликатов по лидам\контактам\(todo)компаниям
+     * 
+     * @dataProvider duplicateDataProvider
+     * @param int $numberOfEntities Количество создаваемых сущностей
+     * @param bool $expectNoMatches Ожидаем ли отсутствие совпадений
+     * @return void
+     * @throws BaseException
+     * @throws TransportException
+     * @covers \Bitrix24\SDK\Services\CRM\Duplicates\Service\Duplicate
+     * @covers \Bitrix24\SDK\Services\CRM\Duplicates\Result\DuplicateResult
+     */
+    public function testEntityDuplicates(EntityType $entityType, int $numberOfEntities, bool $expectNoMatches): void
+    {
+        $email = sprintf('%s@example.com', time());
+        $phone = sprintf('+7444%07d', substr((string)time(), -7));
+        $createdEntityIds = [];
+
+        if (!$expectNoMatches) {
+            for ($i = 0; $i < $numberOfEntities; $i++) {
+                $createdEntityIds[] = $this->createEntity($entityType, $email, $phone, $i);
+            }
+        }
+
+        $this->runDuplicateCheck('email', $email, $createdEntityIds, $expectNoMatches, $entityType);
+        $this->runDuplicateCheck('phone', $phone, $createdEntityIds, $expectNoMatches, $entityType);
+
+        $this->cleanUpEntities($entityType, $createdEntityIds);
+    }
+
+    private function createEntity($entityType, $email, $phone, $index): int
+    {
+        $data = [
+            'NAME' => 'Test' . $index,
+            'EMAIL' => [['VALUE' => $email, 'TYPE' => 'WORK']],
+            'PHONE' => [['VALUE' => $phone, 'TYPE' => 'WORK']]
+        ];
+
+        switch ($entityType) {
+            case EntityType::Contact:
+                return $this->contactService->add($data)->getId();
+            case EntityType::Company:
+                // return $this->companyService->add($data)->getId();
+            case EntityType::Lead:
+                return $this->leadService->add($data)->getId();
+            default:
+                throw new \Exception("Unsupported entity type: $entityType");
+        }
+    }
+
+    private function runDuplicateCheck(string $method, string $value, array $createdEntityIds, bool $expectNotFound, EntityType $entityType): void
+    {
+        $result = $method === 'email' ? $this->duplicate->findByEmail([$value], $entityType) : $this->duplicate->findByPhone([$value], $entityType);
+        $expectNotFound ? $this->assertResultNotFound($result, $entityType) : $this->assertResultState($result, $createdEntityIds, $entityType);
+    }
+    private function assertResultNotFound($result, EntityType $entityType): void
+    {
+        if ($entityType === EntityType::Contact) {
+            $this->assertFalse($result->hasOneContact());
+            $this->assertFalse($result->hasDuplicateContacts());
+            $this->assertCount(0, $result->getContactsId());
+        }
+
+        $this->assertFalse($result->hasOne($entityType));
+        $this->assertFalse($result->hasDuplicates($entityType));
+        $this->assertFalse($result->hasMatches($entityType));
+        $this->assertFalse($result->hasAnyMatches());
+        $this->assertCount(0, $result->getEntityIds($entityType));
+        $this->assertNull($result->getMatchId($entityType, "desc"));
+        $this->assertNull($result->getMatchIdByPriority([$entityType]));
+    }
+
+
+    private function assertResultState($result, array $createdEntityIds, EntityType $entityType): void
+    {
+        $hasDuplicates = count($createdEntityIds) > 1;
+        $hasOne = count($createdEntityIds) === 1;
+
+        // Проверка для контактов
+        if ($entityType === EntityType::Contact) {
+            $this->assertEquals($hasOne, $result->hasOneContact());
+            $this->assertEquals($hasDuplicates, $result->hasDuplicateContacts());
+            $this->assertEquals($createdEntityIds, $result->getContactsId());
+        }
+
+        // Проверка для всех сущностей
+        $this->assertEquals($hasOne, $result->hasOne($entityType));
+        $this->assertEquals($hasDuplicates, $result->hasDuplicates($entityType));
+        $this->assertTrue($result->hasMatches($entityType));
+        $this->assertTrue($result->hasAnyMatches());
+
+        $this->assertEquals($createdEntityIds, $result->getEntityIds($entityType));
+
+        // Проверка сортировки ID
+        if ($hasOne || $hasDuplicates) {
+            $expectedDescId = max($createdEntityIds);
+            $expectedAscId = min($createdEntityIds);
+
+            $this->assertEquals($expectedDescId, $result->getMatchId($entityType, "desc"), "ID in DESC order does not match the expected.");
+            $this->assertEquals($expectedAscId, $result->getMatchId($entityType, "asc"), "ID in ASC order does not match the expected.");
+        }
+
+        foreach (['desc', 'asc'] as $sortOrder) {
+            $matchByPriority = $result->getMatchIdByPriority($entityTypesOrder = [EntityType::Lead, EntityType::Contact, EntityType::Company], $sortOrder);
+            if ($matchByPriority !== null) {
+                $this->assertNotNull($matchByPriority);
+                $this->assertContains($matchByPriority['id'], $createdEntityIds, "Match ID by priority for $sortOrder does not match one of the created entity IDs.");
+
+                if ($sortOrder === 'desc') {
+                    $this->assertEquals($expectedDescId, $matchByPriority['id'], "Match ID by priority for DESC does not match the expected.");
+                } else {
+                    $this->assertEquals($expectedAscId, $matchByPriority['id'], "Match ID by priority for ASC does not match the expected.");
+                }
+            }
+        }
+    }
+    private function cleanUpEntities($entityType, array $entityIds): void
+    {
+        foreach ($entityIds as $entityId) {
+            switch ($entityType) {
+                case EntityType::Contact:
+                    $this->contactService->delete($entityId);
+                    break;
+                case EntityType::Company:
+                    // $this->companyService->delete($entityId);
+                    break;
+                case EntityType::Lead:
+                    $this->leadService->delete($entityId);
+                    break;
+            }
+        }
+    }
+
+    public static function duplicateDataProvider(): array
+    {
+        return [
+            // Test cases for contacts
+            'One contact, no duplicates' => [EntityType::Contact, 1, false],
+            'Two contacts, have duplicates' => [EntityType::Contact, 2, false],
+            'Three contacts, have duplicates' => [EntityType::Contact, 3, false],
+            'Contacts not found' => [EntityType::Contact, 0, true],
+            // Test cases for companies (no service)
+            // 'One company, no duplicates' => [EntityType::Company, 1, false],
+            // 'Two companies, have duplicates' => [EntityType::Company, 2, false],
+            // 'Three companies, have duplicates' => [EntityType::Company, 3, false],
+            // 'Companies not found' => [EntityType::Company, 0, true],
+            // Test cases for leads
+            'One lead, no duplicates' => [EntityType::Lead, 1, false],
+            'Two leads, have duplicates' => [EntityType::Lead, 2, false],
+            'Three leads, have duplicates' => [EntityType::Lead, 3, false],
+            'Leads not found' => [EntityType::Lead, 0, true],
+        ];
+    }
+
+
+     /**
+     * @dataProvider priorityOrderProvider
+     * @param array $priorityOrders
+     * @return void
+     * @throws BaseException
+     * @throws TransportException
+     * @covers \Bitrix24\SDK\Services\CRM\Duplicates\Result\DuplicateResult::getMatchIdByPriority
+     */
+    public function testGetMatchIdByPriorityWithDataProvider(array $priorityOrders)
+    {
+        // Шаг 1: Создание сущностей с одинаковыми контактными данными
+        $email = sprintf('%s@example.com', time());
+        $phone = sprintf('+7444%07d', substr((string)time(), -7));
+
+        $entities = [
+            'Lead' => $this->createEntity(EntityType::Lead, $email, $phone, 0),
+            'Contact' => $this->createEntity(EntityType::Contact, $email, $phone, 1),
+            // 'Company' => $this->createEntity(EntityType::Company, $email, $phone, 2),
+        ];
+
+        // Шаг 2: Поиск дубликатов без указания EntityType
+        $duplicateResult = $this->duplicate->findByPhone([$phone], null);
+
+        // Шаг 3: Проверка getMatchIdByPriority с разными приоритетами из $priorityOrders
+        foreach ($priorityOrders as $priorityOrder) {
+            $match = $duplicateResult->getMatchIdByPriority($priorityOrder, 'desc');
+            $expectedEntity = reset($priorityOrder); // Первый в приоритете тип сущности
+            $expectedId = $entities[$expectedEntity->name];
+
+            $this->assertNotNull($match);
+            $this->assertEquals($expectedId, $match['id']);
+            $this->assertEquals($expectedEntity, $match['entityType']);
+            $this->assertEquals($expectedEntity->value, $match['entityTypeValue']);
+        }
+
+        // Очистка созданных сущностей
+        foreach ($entities as $entityType => $id) {
+            $this->cleanUpEntities($entityType, [$id]);
+        }
+    }
+
+    /**
+     * Data provider for testGetMatchIdByPriority.
+     */
+    public static function priorityOrderProvider()
+    {
+        return [
+            'Lead > Contact > Company' => [[[EntityType::Lead, EntityType::Contact, EntityType::Company]]],
+            'Contact > Lead > Company' => [[[EntityType::Contact, EntityType::Lead, EntityType::Company]]],
+            // 'Company > Lead > Contact' => [[[EntityType::Contact, EntityType::Lead, EntityType::Company]]],
+        ];
+    }
+
 
     /**
      * @return void
@@ -24,7 +246,7 @@ class DuplicateTest extends TestCase
      */
     public function testDuplicatesByEmailNotFound(): void
     {
-        $res = $this->duplicate->findByEmail([sprintf('%s@gmail.com', time())]);
+        $res = $this->duplicate->findByEmail([sprintf('%s@gmail.com', time())], null);
         $this->assertFalse($res->hasDuplicateContacts());
         $this->assertFalse($res->hasOneContact());
         $this->assertCount(0, $res->getContactsId());
@@ -50,7 +272,7 @@ class DuplicateTest extends TestCase
             ]
         ])->getId();
 
-        $res = $this->duplicate->findByEmail([$email]);
+        $res = $this->duplicate->findByEmail([$email], null);
         $this->assertFalse($res->hasDuplicateContacts());
         $this->assertTrue($res->hasOneContact());
         $this->assertCount(1, $res->getContactsId());
@@ -64,17 +286,12 @@ class DuplicateTest extends TestCase
      */
     public function testDuplicatesByPhoneNotFound(): void
     {
-        $res = $this->duplicate->findByPhone([sprintf('+1%s', time())]);
+        $res = $this->duplicate->findByPhone([sprintf('+1%s', time())], null);
         $this->assertFalse($res->hasDuplicateContacts());
         $this->assertFalse($res->hasOneContact());
         $this->assertCount(0, $res->getContactsId());
     }
 
 
-    public function setUp(): void
-    {
-        $this->contactService = Fabric::getServiceBuilder()->getCRMScope()->contact();
-        $this->duplicate = Fabric::getServiceBuilder()->getCRMScope()->duplicate();
-
-    }
+    
 }


### PR DESCRIPTION
- add Methods for check company/lead
- add Methods for results for company/lead
- add Method hasMatches - Checks if there are any matches for a given entity type.
- add Method hasAnyMatches - Checks if there are any matches across all entity types (if search for all types)
- changed findByPhone\findByEmail - requies EntityType or null
- add Method getMatchId - return match by sort
- add Method getMatchIdByPriority - return first match by EntityType priority and sort
- integration tests
- Docs

1. При использовании методов findByPhone\findByEmail - нужно обязательно передавать EntityType или  null если мы явно планируем искать по всем видам сущностей. 
В прошлой версии не требовало явно указывать. имхо  так правильнее - чтобы явно было понятно какой результат будет в итоге.

2. Оставил существующие методы "под контакты" для обратной совместимости
hasDuplicateContacts
hasOneContact
getContactsId

Но в принципе со всеми сущностями можно работать через 
hasDuplicates
hasOne
getEntityIds

Для единообразия - можно конечно для каждой сущности по 3 метода дописать.. но не знаю нужно ли

3. Общий смысл доработок:
- Поддержка всех видов сущностей
- Поддержка расширенной работы с результатами. Несмотря что методы вроде как предназначены для поисков дубликатов, по факту это единственные методы которые позволяют легко найти любую сущность по контакту-емейлу, не оглядываясь на формат записи номера в Б24. Как следствие метод используются в скриптах обработки лидов, когда нужна проверка "А есть ли у нас уже сущность с такими контактами"
Как следствие - нужны способы проверить есть ли сущность, быстро получить ID сущности, а также задать приоритетность поиска. В разных сценариях бывает нужна первая\последняя сущность.

Например стандартная логика для телефонии - поиск по приоритету лид-контакт-компания с возвратом последнего найденного совпадения. В текущем классе это возможно через getMatchIdByPriority с сортировкой desc