### PR TITLE
Add default arguments handling in User.get method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,7 @@
 ### Bugfix
 
 * fix [typehint for Bitrix24 User entity with field ID](https://github.com/mesilov/bitrix24-php-sdk/issues/382)    
+* fix [default arguments for Bitrix24 User get method](https://github.com/mesilov/bitrix24-php-sdk/issues/381)    
 
 ## 2.0-beta.2 — 1.04.2024
 

--- a/src/Services/User/Service/User.php
+++ b/src/Services/User/Service/User.php
@@ -70,6 +70,10 @@ class User extends AbstractService
      */
     public function get(array $order, array $filter, bool $isAdminMode = false): UsersResult
     {
+        if ($order === []) {
+            $order = ['ID' => 'ASC'];
+        }
+
         return new UsersResult($this->core->call('user.get', [
             'sort' => array_keys($order)[0],
             'order' => array_values($order)[0],

--- a/tests/Integration/Services/User/Service/UserTest.php
+++ b/tests/Integration/Services/User/Service/UserTest.php
@@ -48,6 +48,12 @@ class UserTest extends TestCase
         );
     }
 
+    #[TestDox('test get users list with default arguments')]
+    public function testGetWithDefaultArguments(): void
+    {
+        $this->assertGreaterThanOrEqual(1, $this->userService->get([], [], true)->getCoreResponse()->getResponseData()->getPagination()->getTotal());
+    }
+
     /**
      * @throws BaseException
      * @throws TransportException


### PR DESCRIPTION
A check has been added in User.get method, to set a default argument as ascending order of IDs when no explicit order is provided. A corresponding test case 'test get users list with default arguments' has also been included to validate the functionality. The CHAGELOG.md is updated to reflect this fix.