### PR TITLE
Replace `ramsey/uuid` with `symfony/uid` package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 * improve DX - add [Rector](https://github.com/rectorphp/rector) for improve code quality and speed up releases cycle 
 
 ### Changed
+* ❗️ migrate from `ramsey/uuid` to `symfony/uid`
 * ❗️ update scope `telephony`, scope fully rewritten
     * `ExternalCall` – work with external call:
         * `getCallRecordUploadUrl` – get url for upload call record file
@@ -115,7 +116,9 @@
     * add `CrmEntityType` – crm entity type enum
     * add `PbxType` – pbx type enum
     * add `SipRegistrationStatus` – pbx sip line registration status
-* change signature `Bitrix24\SDK\Core\Credentials\AccessToken::getRefreshToken()?string;` - add nullable option for event tokens    
+* change signature `Bitrix24\SDK\Core\Credentials\AccessToken::getRefreshToken()?string;` - add nullable option for event tokens
+* change signature `Bitrix24\SDK\Core\Commands\Command::getName():?string` renamed to `getId():string`
+
 
 ### Deleted
 * remove class `Bitrix24\SDK\Application\Requests\Events\OnApplicationInstall\Auth`

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
     "ext-intl": "*",
     "psr/log": "^2 || ^3",
     "fig/http-message-util": "1.1.*",
-    "ramsey/uuid": "^3 ||^4",
     "nesbot/carbon": "3.3.*",
     "moneyphp/money": "^3 || ^4",
     "symfony/http-client": "^6 || ^7",

--- a/src/Core/Batch.php
+++ b/src/Core/Batch.php
@@ -737,7 +737,7 @@ class Batch implements BatchOperationsInterface
                 [
                     'batchItemNumber' => $batchItem,
                     'batchApiCommand' => $traversableBatchResult->getApiCommand()->getApiMethod(),
-                    'batchApiCommandUuid' => $traversableBatchResult->getApiCommand()->getUuid()->toString(),
+                    'batchApiCommandId' => $traversableBatchResult->getApiCommand()->getId(),
                 ]
             );
             // todo try to multiplex requests
@@ -831,7 +831,7 @@ class Batch implements BatchOperationsInterface
     {
         $apiCommands = [];
         foreach ($this->commands as $command) {
-            $apiCommands[$command->getName() ?? $command->getUuid()->toString()] = sprintf(
+            $apiCommands[$command->getId()] = sprintf(
                 '%s?%s',
                 $command->getApiMethod(),
                 http_build_query($command->getParameters())

--- a/src/Core/Commands/Command.php
+++ b/src/Core/Commands/Command.php
@@ -4,35 +4,18 @@ declare(strict_types=1);
 
 namespace Bitrix24\SDK\Core\Commands;
 
-use Ramsey\Uuid\Uuid;
-use Ramsey\Uuid\UuidInterface;
+use Symfony\Component\Uid\Uuid;
 
-/**
- * Class Command
- *
- * @package Bitrix24\SDK\Core\Commands
- */
 class Command
 {
-    private readonly string $name;
-
-    private readonly \Ramsey\Uuid\UuidInterface $uuid;
-
-    /**
-     * BatchCommand constructor.
-     *
-     *
-     * @throws \Exception
-     */
-    public function __construct(private readonly string $apiMethod, private readonly array $parameters, ?string $name = null)
+    public function __construct(
+        private readonly string $apiMethod,
+        private readonly array  $parameters,
+        private ?string         $id = null)
     {
-        $this->uuid = Uuid::uuid4();
-        $this->name = $name ?? $this->uuid->toString();
-    }
-
-    public function getUuid(): UuidInterface
-    {
-        return $this->uuid;
+        if ($id === null) {
+            $this->id = (Uuid::v7())->toRfc4122();
+        }
     }
 
     public function getApiMethod(): string
@@ -45,8 +28,8 @@ class Command
         return $this->parameters;
     }
 
-    public function getName(): ?string
+    public function getId(): string
     {
-        return $this->name;
+        return $this->id;
     }
 }


### PR DESCRIPTION
The existing dependency on `ramsey/uuid` has been replaced with `symfony/uid` in the codebase. This change is reflected in the `Command` constructor of `src/Core/Commands/Command.php`, and anywhere else where the ID of a command was previously retrieved using `getUuid()`. The `getName()` method has also been replaced with `getId()`. The composer.json and CHANGELOG files have been updated correspondingly.